### PR TITLE
[18.0][FIX] account_statement_import_sheet_file: fix none separator

### DIFF
--- a/account_statement_import_sheet_file/models/account_statement_import_sheet_mapping.py
+++ b/account_statement_import_sheet_file/models/account_statement_import_sheet_mapping.py
@@ -27,6 +27,9 @@ class AccountStatementImportSheetMapping(models.Model):
         string="Decimals Separator",
         selection=[("dot", "dot (.)"), ("comma", "comma (,)"), ("none", "none")],
         default="comma",
+        help="When the separator is 'none', the value will be shifted according "
+        "to the currency decimals. For example, 12345 will be converted to "
+        "123.45",
     )
     file_encoding = fields.Selection(
         string="Encoding",

--- a/account_statement_import_sheet_file/models/account_statement_import_sheet_parser.py
+++ b/account_statement_import_sheet_file/models/account_statement_import_sheet_parser.py
@@ -1,5 +1,6 @@
 # Copyright 2019 ForgeFlow, S.L.
 # Copyright 2020 CorporateHub (https://corporatehub.eu)
+# Copyright 2025 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 import itertools
@@ -539,5 +540,14 @@ class AccountStatementImportSheetParser(models.TransientModel):
             or "0"
         )
         value = value.replace(thousands, "")
-        value = value.replace(decimal, ".")
+        float_separator = "."
+        if decimal:
+            value = value.replace(decimal, float_separator)
+        else:
+            journal = self.env["account.journal"].browse(
+                self.env.context.get("journal_id")
+            )
+            currency = journal.currency_id or journal.company_id.currency_id
+            decimal_places = currency.decimal_places if currency else 2
+            value = value[:-decimal_places] + float_separator + value[-decimal_places:]
         return float(value)

--- a/account_statement_import_sheet_file/readme/CONTRIBUTORS.md
+++ b/account_statement_import_sheet_file/readme/CONTRIBUTORS.md
@@ -11,3 +11,4 @@
 - [CorporateHub](https://corporatehub.eu/)
   - Alexey Pelykh \<<alexey.pelykh@corphub.eu>\>
 - Sebastiano Picchi <sebastiano.picchi@pytech.it>
+- Jacques-Etienne Baudoux (BCIM) <je@bcim.be>

--- a/account_statement_import_sheet_file/tests/test_account_statement_import_sheet_file.py
+++ b/account_statement_import_sheet_file/tests/test_account_statement_import_sheet_file.py
@@ -1,5 +1,6 @@
 # Copyright 2019 ForgeFlow, S.L.
 # Copyright 2020 CorporateHub (https://corporatehub.eu)
+# Copyright 2025 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from base64 import b64encode
@@ -55,6 +56,8 @@ class TestAccountStatementImportSheetFile(BaseCommon):
         cls.mock_mapping_comma_dot._get_float_separators.return_value = (",", ".")
         cls.mock_mapping_dot_comma = Mock()
         cls.mock_mapping_dot_comma._get_float_separators.return_value = (".", ",")
+        cls.mock_mapping_none_none = Mock()
+        cls.mock_mapping_none_none._get_float_separators.return_value = ("", "")
 
     def _data_file(self, filename, encoding=None):
         mode = "rt" if encoding else "rb"
@@ -653,6 +656,11 @@ class TestAccountStatementImportSheetFile(BaseCommon):
                 1234567.89,
                 self.mock_mapping_dot_comma,
             ),  # inverted separators
+            (
+                "123456",
+                1234.56,
+                self.mock_mapping_none_none,
+            ),  # no separator
         ]
 
         for value, expected, mock_mapping in test_cases:


### PR DESCRIPTION
Allow to parse "123456" as 1234.56 when using "none" as decimal separator

Before it was returning "1.2.3.4.5.6" and crashing

Port of https://github.com/OCA/bank-statement-import/pull/805